### PR TITLE
Setup local development database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13.9
+FROM pgvector/pgvector:pg16
 ENV POSTGRES_PASSWORD docker
 ENV POSTGRES_DB zuugle_suchseite_dev
 EXPOSE 5433

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ and install all dependencies.
 ### Setup database PostgreSQL 16
 1. Install (https://www.docker.com/) on your local machine
 2. Execute these two commands: 
-
+    ```
     docker build -t zuugle-postgres-db ./
 
-    docker run -d --name zuugle-container -p 5433:5432 zuugle-postgres-db
-
+    docker run -d --name zuugle-container -p 5433:5432 zuugle-postgres-db 
+    ```
 ### Setup database connection files
 Create a copy of each connection file and rename it. We need four "knexfile*" files in the end. 
 
@@ -31,11 +31,19 @@ Create a copy of each connection file and rename it. We need four "knexfile*" fi
 
 
 ## Load data and run backend
-### Import data locally
+### Restore database into local docker instance
 
     npm run build
 
-    npm run import-data-full
+    npm run import-data-docker
+
+### Create GPX files and images
+
+Start API locally:
+
+    npm run start
+
+And in a new terminal start the update script:
 
     npm run import-files
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "import-data": "node build/jobs/syncData.js",
     "import-data-full": "node build/jobs/syncData.js",
+    "import-data-docker": "docker cp zuugle_postgresql.dump zuugle-container:/ && node build/jobs/syncDataDocker.js",
     "import-data-prod": "node build/jobs/syncDataProd.js",
     "import-files": "node build/jobs/syncFiles.js",
     "import-files-prod": "node build/jobs/syncFiles.js",
@@ -32,6 +33,7 @@
     "babel-cli": "^6.10.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
+    "cross-spawn": "^7.0.6",
     "nodemon": "^3.0.1"
   },
   "dependencies": {
@@ -45,7 +47,6 @@
     "knex": "^3.0.1",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.45",
-    
     "multer": "^1.3.0",
     "mysql": "^2.18.1",
     "mysql2": "^3.6.2",

--- a/src/jobs/syncDataDocker.js
+++ b/src/jobs/syncDataDocker.js
@@ -1,0 +1,18 @@
+#!/usr/bin/node
+import {
+    writeKPIs,
+    truncateAll,
+    restoreDump
+} from "./sync.js";
+
+console.log('Truncate tables');
+truncateAll().then(_ => {
+    console.log('Restore from database dump (this will take a while)');
+    restoreDump().then(_ => {
+        console.log('Write KPIs');
+        writeKPIs().then(_ => {
+            console.log('Database ready!');
+            process.exit();
+        })
+    });
+});


### PR DESCRIPTION
Fixes #169

- updates docker image
- new file `syncDataDocker.js` with logic to populate database in docker image from dump
- adds 2 helper functions to `sync.js`:
  -  `truncateAll()` 
  - `restoreDump()` which starts `pg_restore` from inside the docker container for the database
- adds script `import-data-docker` in `package.json`
- updates `README`