### PR TITLE
Add Docker setup for UAT and DEV databases and ensure deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "nodemon --trace-warnings --watch ./src --exec babel-node -- src/index.js",
-    "build": "babel src -d build && cp -r ./templates  ./build/templates",
+    "build": "babel src -d build && cp -r ./templates  ./build/templates && cp Dockerfile database.sql docker-compose.yml restore_databases.sh INSTALL_DOCKER_DB.md ./build/",
     "test": "jest",
     "import-data": "node build/jobs/syncData.js",
     "import-data-full": "node build/jobs/syncData.js",


### PR DESCRIPTION
- Created `docker-compose.yml` to spin up two PostgreSQL instances (UAT on 5432, DEV on 5433) using the repository's database Dockerfile.
- Modified `src/jobs/sync.js` to allow configuration of container name, database name, and user via environment variables.
- Updated database dump handling to use `/tmp/` directory inside containers for better compatibility.
- Created `restore_databases.sh` script to automate daily restore for both environments.
- Added `INSTALL_DOCKER_DB.md` with setup instructions and the required `knexfile.js` configuration.
- Updated `package.json` build script to include `Dockerfile`, `database.sql`, `docker-compose.yml`, `restore_databases.sh`, and `INSTALL_DOCKER_DB.md` in the build artifact so they are deployed to the server.
- Updated `restore_databases.sh` to dynamically find the sync script depending on execution context (local vs server).