### PR TITLE
Replaced materialized view with normal table

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -366,11 +366,13 @@ CREATE INDEX type_idx ON pois (type);
 CREATE INDEX idx_pois_name_search ON pois (name text_pattern_ops);
 
 
----------------------------------------------------------------
---- Materialized View: vw_search_suggestions                ---
----------------------------------------------------------------
----                                                         ---
---- The materialized view vw_search_suggestions and all the ---
---- indexes are created and maintained by the sync.js job.  ---
----                                                         ---
----------------------------------------------------------------
+CREATE TABLE search_suggestions (
+    reachable_from_country char(2) NOT NULL,
+    city_slug varchar(64) NOT NULL,
+    term text NOT NULL,
+    number_of_tours integer,
+    PRIMARY KEY (reachable_from_country, city_slug, term)
+);
+CREATE INDEX idx_suggestions_search
+ON search_suggestions (reachable_from_country, city_slug, term text_pattern_ops)
+INCLUDE (number_of_tours);


### PR DESCRIPTION
My idea using a materialized view was not working, as we are switching the city2tour_flat with a new table, every day. So I dropped the idea of a materialized view and build a normal table. The few seconds, while this table is updated, no search suggestions are presented. At 2:00 AM this is a minor problem.

I pimped the actual SQL in autocompleteWrapper  a little more: city2tour is sufficient to call, instead of the bigger table city2tour_flat and now peaks are highest priority. Huts and terms share same priority. A term is higher rated, if used in more tours.