### PR TITLE
Fixed insert of terms in sync.js and updated PostgreSQL database to v18

### DIFF
--- a/.github/workflows/deploy2dev.yml
+++ b/.github/workflows/deploy2dev.yml
@@ -32,6 +32,11 @@ jobs:
               run: npm install
             - name: Run build task
               run: npm run build
+            - name: Unlock network access to server
+              run: |
+                  curl -s -o /dev/null -w "HTTP Status: %{http_code}\n" "${{ secrets.DEPLOY_ACCESS }}"
+                  echo "Waiting 59 seconds for access rule to activate..."
+                  sleep 59
             - name: Deploy to Server
               uses: easingthemes/ssh-deploy@main
               with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Dieses Projekt folgt einem strikten **UAT-First** Workflow.
 ## 🛠 Tech Stack
 
 - **Runtime:** Node.js v20.5.0 (verwende `nvm`).
-- **Datenbank:** PostgreSQL 16 (Lokal via Docker auf Port 5433, Server auf Standard).
+- **Datenbank:** PostgreSQL 18 (Lokal via Docker auf Port 5433, Server auf Standard).
 - **ORM/Query Builder:** Knex.js.
 - **Framework:** Node.js Backend (siehe `package.json` für spezifische Routing-Libs).
 - **Logging:** Custom Logger schreibt lokal in `logs/api.logs`.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ View logs:
 
     docker compose logs -f
 
+### Rebuild containers (Version Upgrade or Clean Rebuild)
+
+To upgrade the PostgreSQL version or completely rebuild the database structure:
+
+1. Build the script: `npm run build`
+2. Run rebuild: `npm run rebuild-docker`
+3. Import data: `npm run import-data-docker`
+
 ## Follow frontend Readme
 
 Follow the steps described at https://github.com/bahnzumberg/zuugle-suchseite#zuugleat-suchseite

--- a/README_UAT.md
+++ b/README_UAT.md
@@ -32,41 +32,6 @@ You should see `zuugle-postgres-uat`, `zuugle-postgres-dev`, and `zuugle-valkey`
 
 Configure `src/knexfile.js` to connect to the Docker containers.
 
-**UAT (production profile)** - Port 5434:
-
-```javascript
-production: {
-    client: 'pg',
-    version: '18',
-    containerName: 'zuugle-postgres-uat',
-    connection: {
-        host: 'localhost',
-        port: 5434,
-        user: 'zuugle_suche',
-        password: 'docker',
-        database: 'zuugle_suchseite_db'
-    },
-    pool: { min: 2, max: 10 }
-}
-```
-
-**DEV (development profile)** - Port 5433:
-
-```javascript
-development: {
-    client: 'pg',
-    version: '18',
-    containerName: 'zuugle-postgres-dev',
-    connection: {
-        host: 'localhost',
-        port: 5433,
-        user: 'postgres',
-        password: 'docker',
-        database: 'zuugle_suchseite_dev'
-    },
-    pool: { min: 2, max: 10 }
-}
-```
 
 ### 4. Initial database restore
 

--- a/README_UAT.md
+++ b/README_UAT.md
@@ -32,7 +32,6 @@ You should see `zuugle-postgres-uat`, `zuugle-postgres-dev`, and `zuugle-valkey`
 
 Configure `src/knexfile.js` to connect to the Docker containers.
 
-
 ### 4. Initial database restore
 
 Run the restore script manually to populate data:

--- a/README_UAT.md
+++ b/README_UAT.md
@@ -37,7 +37,7 @@ Configure `src/knexfile.js` to connect to the Docker containers.
 ```javascript
 production: {
     client: 'pg',
-    version: '16',
+    version: '18',
     containerName: 'zuugle-postgres-uat',
     connection: {
         host: 'localhost',
@@ -55,7 +55,7 @@ production: {
 ```javascript
 development: {
     client: 'pg',
-    version: '16',
+    version: '18',
     containerName: 'zuugle-postgres-dev',
     connection: {
         host: 'localhost',
@@ -111,6 +111,15 @@ docker compose -f docker-compose.uat.yaml down -v
 # View logs
 docker compose -f docker-compose.uat.yaml logs -f
 ```
+
+### Rebuild containers (Version Upgrade or Clean Rebuild)
+
+On the UAT server, you can rebuild any of the two DB containers:
+
+1. Set environment: `export NODE_ENV=production` (for UAT) or `export NODE_ENV=development` (for DEV)
+2. Build the script: `npm run build`
+3. Run rebuild: `npm run rebuild-docker`
+4. Restore data: `./restore_databases.sh`
 
 ## Configuration Summary
 

--- a/docker-compose.uat.yaml
+++ b/docker-compose.uat.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # UAT environment setup: Two PostgreSQL instances + Valkey cache
 # Usage: docker compose -f docker-compose.uat.yaml up -d
 services:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # Local development setup: Single PostgreSQL + Valkey cache
 services:
     postgres:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "import-data-full": "node build/jobs/syncDataProd.js",
         "import-data-docker": "node build/jobs/syncDataDocker.js",
         "reset-database": "node build/jobs/resetDatabase.js",
+        "rebuild-docker": "node build/jobs/rebuildDocker.js",
         "import-data-docker-download": "node build/jobs/syncDataDockerDownload.js",
         "import-data-prod": "node build/jobs/syncDataProd.js",
         "import-files": "node build/jobs/syncFiles.js",

--- a/restore_databases.sh
+++ b/restore_databases.sh
@@ -65,6 +65,17 @@ if [ -z "$DB_USER" ]; then
     exit 1
 fi
 
+# Ensure Valkey cache container is running (shared across UAT/DEV)
+if docker ps --format '{{.Names}}' | grep -q '^zuugle-valkey$'; then
+    echo "Valkey container already running."
+elif docker ps -a --format '{{.Names}}' | grep -q '^zuugle-valkey$'; then
+    echo "Starting existing Valkey container..."
+    docker start zuugle-valkey
+else
+    echo "Creating Valkey container..."
+    docker run -d --name zuugle-valkey --restart always -p 127.0.0.1:6379:6379 valkey/valkey:8-alpine
+fi
+
 # Rebuild database structure if --structure flag is set
 if [ "$REBUILD_STRUCTURE" = true ]; then
     echo "Rebuilding database structure from database.sql..."

--- a/src/jobs/rebuildDocker.js
+++ b/src/jobs/rebuildDocker.js
@@ -1,0 +1,226 @@
+/**
+ * rebuildDocker.js
+ *
+ * Stops, removes, and recreates the Docker PostgreSQL container for the
+ * current environment. This is useful for:
+ *   - PostgreSQL version upgrades (new Docker image)
+ *   - Database schema changes (database.sql is re-applied on fresh container)
+ *
+ * The correct container and docker-compose file are determined automatically
+ * from the knexfile.js configuration (containerName field).
+ *
+ * Usage: npm run rebuild-docker
+ *
+ * NOTE: This script refuses to run on production (NODE_ENV=production on
+ *       a machine without docker-compose files), where PostgreSQL is
+ *       installed natively and must be maintained manually.
+ */
+
+import { execSync } from "child_process";
+import * as path from "path";
+import * as fs from "fs";
+import * as readline from "readline";
+
+// --- Container-to-Service mapping ---
+// Maps container names to their docker-compose file and service name.
+const CONTAINER_MAP = {
+    "zuugle-container": {
+        composeFile: "docker-compose.yaml",
+        serviceName: "postgres",
+    },
+    "zuugle-postgres-uat": {
+        composeFile: "docker-compose.uat.yaml",
+        serviceName: "postgres-uat",
+    },
+    "zuugle-postgres-dev": {
+        composeFile: "docker-compose.uat.yaml",
+        serviceName: "postgres-dev",
+    },
+};
+
+function getProjectRoot() {
+    // From build/jobs/ → project root is ../../
+    // From src/jobs/  → project root is ../../
+    const possibleRoots = [
+        path.resolve(__dirname, "../../"),
+        path.resolve(__dirname, "../../../"),
+        path.resolve(process.cwd()),
+    ];
+    for (const root of possibleRoots) {
+        if (fs.existsSync(path.join(root, "docker-compose.yaml"))) {
+            return root;
+        }
+    }
+    return process.cwd();
+}
+
+function loadKnexConfig() {
+    const knexfilePath = path.resolve(__dirname, "../knexfile.js");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(knexfilePath);
+}
+
+function getContainerName(knexConfig) {
+    const env = process.env.NODE_ENV || "development";
+    if (knexConfig[env] && knexConfig[env].containerName) {
+        return knexConfig[env].containerName;
+    }
+    return process.env.DB_CONTAINER_NAME || "zuugle-container";
+}
+
+function ask(question) {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+    return new Promise((resolve) => {
+        rl.question(question, (answer) => {
+            rl.close();
+            resolve(answer.trim());
+        });
+    });
+}
+
+function run(cmd, opts = {}) {
+    console.log(`  → ${cmd}`);
+    try {
+        execSync(cmd, { stdio: "inherit", ...opts });
+        return true;
+    } catch (err) {
+        if (!opts.ignoreError) {
+            throw err;
+        }
+        return false;
+    }
+}
+
+function waitForDatabase(containerName, dbUser, maxRetries = 30) {
+    console.log("\n⏳ Waiting for PostgreSQL to be ready...");
+    for (let i = 1; i <= maxRetries; i++) {
+        try {
+            execSync(`docker exec ${containerName} pg_isready -U ${dbUser}`, { stdio: "pipe" });
+            console.log("✅ PostgreSQL is ready.\n");
+            return true;
+        } catch {
+            if (i < maxRetries) {
+                execSync("sleep 1");
+            }
+        }
+    }
+    console.error("❌ PostgreSQL did not become ready in time.");
+    return false;
+}
+
+async function main() {
+    const env = process.env.NODE_ENV || "development";
+
+    // --- Safety check: refuse to run on production server ---
+    if (env === "production") {
+        const projectRoot = getProjectRoot();
+        const hasUatCompose = fs.existsSync(path.join(projectRoot, "docker-compose.uat.yaml"));
+        if (!hasUatCompose) {
+            console.error("");
+            console.error("❌ ERROR: This script cannot run on production.");
+            console.error("   Production uses a natively installed PostgreSQL database");
+            console.error("   that must be maintained manually.");
+            console.error("");
+            process.exit(1);
+        }
+        // If docker-compose.uat.yaml exists, we're on the UAT server —
+        // production profile there means the UAT database, which is OK.
+    }
+
+    // --- Load configuration ---
+    const knexConfig = loadKnexConfig();
+    const containerName = getContainerName(knexConfig);
+    const mapping = CONTAINER_MAP[containerName];
+
+    if (!mapping) {
+        console.error(`❌ Unknown container: "${containerName}"`);
+        console.error("   Known containers:", Object.keys(CONTAINER_MAP).join(", "));
+        process.exit(1);
+    }
+
+    const projectRoot = getProjectRoot();
+    const composeFilePath = path.join(projectRoot, mapping.composeFile);
+
+    if (!fs.existsSync(composeFilePath)) {
+        console.error(`❌ Compose file not found: ${composeFilePath}`);
+        process.exit(1);
+    }
+
+    const dbUser = knexConfig[env]?.connection?.user || process.env.DB_USER || "postgres";
+
+    // --- Show what we're about to do ---
+    console.log("");
+    console.log("==============================================");
+    console.log("     ZUUGLE DOCKER CONTAINER REBUILD");
+    console.log("==============================================");
+    console.log("");
+    console.log(`  Environment:    ${env}`);
+    console.log(`  Container:      ${containerName}`);
+    console.log(`  Compose file:   ${mapping.composeFile}`);
+    console.log(`  Service:        ${mapping.serviceName}`);
+    console.log(`  DB User:        ${dbUser}`);
+    console.log("");
+    console.log("  ⚠️  This will DESTROY the container and all its data.");
+    console.log("     The database will be recreated empty from database.sql.");
+    console.log("     You will need to run 'npm run import-data-docker' afterwards.");
+    console.log("");
+
+    const confirm = await ask("Continue? (Y/N): ");
+    if (confirm.toUpperCase() !== "Y") {
+        console.log("Aborted.");
+        process.exit(0);
+    }
+
+    const composeCmd = `docker compose -f ${mapping.composeFile}`;
+
+    // --- Step 1: Stop and remove the container ---
+    console.log("\n[1/4] Stopping container...");
+    run(`${composeCmd} stop ${mapping.serviceName}`, {
+        cwd: projectRoot,
+        ignoreError: true,
+    });
+
+    console.log("\n[2/4] Removing container...");
+    run(`${composeCmd} rm -f ${mapping.serviceName}`, {
+        cwd: projectRoot,
+        ignoreError: true,
+    });
+
+    // --- Step 2: Pull latest image ---
+    console.log("\n[3/4] Pulling latest image...");
+    run(`${composeCmd} pull ${mapping.serviceName}`, { cwd: projectRoot });
+
+    // --- Step 3: Start fresh container ---
+    console.log("\n[4/4] Starting fresh container...");
+    run(`${composeCmd} up -d ${mapping.serviceName}`, { cwd: projectRoot });
+
+    // --- Step 4: Wait for database readiness ---
+    const dbReady = waitForDatabase(containerName, dbUser);
+    if (!dbReady) {
+        console.error("Container started but database is not responding.");
+        process.exit(1);
+    }
+
+    // --- Verify version ---
+    console.log("PostgreSQL version:");
+    run(`docker exec ${containerName} psql --version`);
+
+    console.log("");
+    console.log("==============================================");
+    console.log("  ✅ Container rebuilt successfully!");
+    console.log("");
+    console.log("  Next step: populate the database with data:");
+    console.log("    npm run import-data-docker");
+    console.log("==============================================");
+    console.log("");
+
+    process.exit(0);
+}
+
+main().catch((err) => {
+    console.error("Unexpected error:", err);
+    process.exit(1);
+});

--- a/src/jobs/sync.js
+++ b/src/jobs/sync.js
@@ -1397,12 +1397,14 @@ export async function refreshSearchSuggestions() {
 
         // Insert Terms
         await knex.raw(`
-            INSERT INTO search_suggestions (type, term, reachable_from_country, city_slug, priority, number_of_tours)
+           INSERT INTO search_suggestions (type, term, reachable_from_country, city_slug, priority, number_of_tours)
             WITH extracted_words AS (
+                -- 1. Extract and stem words
                 SELECT
                     c.city_slug,
                     c.reachable_from_country,
                     clean_term.original_word,
+                    t.text_lang,
                     (ts_lexize(
                         (CASE t.text_lang
                             WHEN 'de' THEN 'german_stem'
@@ -1422,26 +1424,56 @@ export async function refreshSearchSuggestions() {
                 ) AS clean_term
             ),
             valid_stems AS (
+                -- 2. IMPORTANT: Discard all stop words (where ts_lexize returns NULL)
                 SELECT 
                     city_slug, 
                     reachable_from_country, 
                     original_word, 
+                    text_lang,
                     stem
                 FROM extracted_words
                 WHERE stem IS NOT NULL 
             ),
+            lang_counts AS (
+                -- 3. REPLACES THE DELETE: Count occurrences per word, language, and stem
+                SELECT 
+                    city_slug,
+                    reachable_from_country,
+                    original_word,
+                    text_lang,
+                    stem,
+                    COUNT(*) as occurrences
+                FROM valid_stems
+                GROUP BY city_slug, reachable_from_country, original_word, text_lang, stem
+            ),
+            best_lang_stems AS (
+                -- 4. REPLACES THE DELETE: Keep only the stem of the most frequent language per original word
+                SELECT
+                    city_slug,
+                    reachable_from_country,
+                    original_word,
+                    stem,
+                    occurrences as number_of_tours,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY city_slug, reachable_from_country, original_word 
+                        ORDER BY occurrences DESC
+                    ) as rnk
+                FROM lang_counts
+            ),
             word_counts AS (
+                -- 5. Take only the "winner" stems and check minimum count (>= 2)
                 SELECT
                     city_slug,
                     reachable_from_country,
                     stem,
                     original_word,
-                    COUNT(original_word) AS number_of_tours
-                FROM valid_stems
-                GROUP BY city_slug, reachable_from_country, stem, original_word
-                HAVING COUNT(original_word) >= 2 
+                    number_of_tours
+                FROM best_lang_stems
+                WHERE rnk = 1 
+                AND number_of_tours >= 2
             ),
             ranked_words AS (
+                -- 6. Find the strongest representative (original_word) for a stem
                 SELECT
                     city_slug,
                     reachable_from_country,
@@ -1454,6 +1486,7 @@ export async function refreshSearchSuggestions() {
                     ) as rank
                 FROM word_counts
             )
+            -- 7. The final insert with conflict resolution (upsert)
             SELECT
                 'term' AS type,
                 original_word AS term,

--- a/src/knexfile.js.example
+++ b/src/knexfile.js.example
@@ -3,7 +3,7 @@
 module.exports = {
   production: {
     client: 'pg',
-    version: '13',
+    version: '18',
     connection: {
       host : '',
       port : 5432,
@@ -18,7 +18,8 @@ module.exports = {
   },
   development: {
     client: 'pg',
-    version: '13',
+    version: '18',
+    containerName: 'zuugle-container',
     connection: {
       host : 'localhost',
       port : 5433,


### PR DESCRIPTION
### Duplicate error in search_suggestions

The big insert query in sync.js, which is preparing the table search_suggestions threw errors while inserting, because sometimes (mostly german) words were found in full_text columns of tourdescriptions found to be written in another language (text_lang). In German the stem resulted in another word as in Italian. This left the original_words in the table, which led to the duplicate errors.

**Example:** 
- German: Höhenmeter -> stem: höhenmeter
- Italian: Höhenmeter -> stem: hohenmeter  

### Update to PostgreSQL v18

- Production database has been updated to PostgreSQL v18.
- There is a new possibility to create a completely fresh docker container with the current database and everything build up green field like: "npm run rebuild-docker" 